### PR TITLE
Add EJSON as a dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function (api) {
     api.versionsFrom('METEOR@1.0');
 
-    api.use(['ddp', 'random', 'underscore', 'mongo', 'minimongo',
+    api.use(['ddp', 'random', 'underscore', 'mongo', 'minimongo', 'ejson',
              'dburles:mongo-collection-instances@0.2.6'], ['client', 'server']);
 
     api.addFiles(['helpers.js', 'mongo-ddp-adaptor.js', 'ddp-framework.js'], ['client', 'server']);


### PR DESCRIPTION
We encountered a problem when trying to defined encrypted fields _inside
a meteor package_ with `_encrypted_fields`, where we get a message
on the client about `EJSON` being undefined. Adding 'ejson' as a dependency
solved this issue for us.
